### PR TITLE
feat: add OAuthClientsService (External connectors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uspacy/sdk",
-  "version": "0.0.233",
+  "version": "0.0.240",
   "repository": "git@github.com:Uspacy/uspacy-js-sdk.git",
   "homepage": "https://uspacy.github.io/uspacy-js-sdk",
   "keywords": [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { MessengerService } from './services/MessengerService';
 import { MigrationsService } from './services/MigrationsService';
 import { NewsFeedService } from './services/NewsFeedService';
 import { NotificationsService } from './services/NotificationsService';
+import { OAuthClientsService } from './services/OAuthClientsService';
 import { PouchdbService } from './services/PouchdbService';
 import { ProfileService } from './services/ProfileService';
 import { ResourcesService } from './services/ResourcesService';
@@ -73,6 +74,7 @@ class Uspacy {
 		public readonly groupsService: GroupsService,
 		public readonly filesService: FilesService,
 		public readonly webhooksService: WebhooksService,
+		public readonly oauthClientsService: OAuthClientsService,
 		public readonly rolesService: RolesService,
 		public readonly notificationsService: NotificationsService,
 		public readonly newsFeedService: NewsFeedService,

--- a/src/models/oauthClients.ts
+++ b/src/models/oauthClients.ts
@@ -1,15 +1,17 @@
+// NOTE: client fields are SNAKE_CASE — the raw shape from auth-service via
+// users-backend (no response camelCase conversion is applied).
 export interface IOAuthClient {
-	clientId: string;
+	client_id: string;
 	name: string;
-	grantTypes: string[];
-	redirectUris: string[] | null;
+	grant_types: string[];
+	redirect_uris: string[] | null;
 	confidential: boolean;
-	userId: number | null;
+	user_id: number | null;
 	domain: string | null;
 	permissions: string[] | null;
 	revoked: boolean;
-	createdAt: string | number;
-	updatedAt: string | number;
+	created_at: string | number;
+	updated_at: string | number;
 }
 
 // The create response additionally includes the one-time plaintext secret.
@@ -32,12 +34,12 @@ export interface IOAuthPermissionGroup {
 	};
 }
 
-// Laravel paginator (flat; camelCased keys), as returned under the response envelope's `data`.
+// Laravel paginator (flat; snake_case keys), as returned under the response envelope's `data`.
 export interface IOAuthClientsPaginator {
-	currentPage: number;
+	current_page: number;
 	data: IOAuthClient[];
-	lastPage: number;
-	perPage: number;
+	last_page: number;
+	per_page: number;
 	total: number;
 	from: number;
 	to: number;

--- a/src/models/oauthClients.ts
+++ b/src/models/oauthClients.ts
@@ -1,0 +1,50 @@
+export interface IOAuthClient {
+	clientId: string;
+	name: string;
+	grantTypes: string[];
+	redirectUris: string[] | null;
+	confidential: boolean;
+	userId: number | null;
+	domain: string | null;
+	permissions: string[] | null;
+	revoked: boolean;
+	createdAt: string | number;
+	updatedAt: string | number;
+}
+
+// The create response additionally includes the one-time plaintext secret.
+export interface IOAuthClientWithSecret extends IOAuthClient {
+	secret: string;
+}
+
+// A permission group for the FE granular selector.
+export interface IOAuthPermissionGroup {
+	key: string; // area.entity, e.g. 'crm.leads'
+	title: string;
+	entity: string; // area.entity
+	section: string; // 'crm' | 'tasks' | 'smart_objects'
+	actions: string[]; // ['create','view','edit','delete']
+	permissionKeys: {
+		create: string;
+		view: string;
+		edit: string;
+		delete: string;
+	};
+}
+
+// Laravel paginator (flat; camelCased keys), as returned under the response envelope's `data`.
+export interface IOAuthClientsPaginator {
+	currentPage: number;
+	data: IOAuthClient[];
+	lastPage: number;
+	perPage: number;
+	total: number;
+	from: number;
+	to: number;
+}
+
+// users-backend wraps every payload in this envelope.
+export interface IApiEnvelope<T> {
+	status: boolean;
+	data: T;
+}

--- a/src/models/oauthClients.ts
+++ b/src/models/oauthClients.ts
@@ -19,13 +19,26 @@ export interface IOAuthClientWithSecret extends IOAuthClient {
 	secret: string;
 }
 
+export enum EOAuthPermissionSection {
+	CRM = 'crm',
+	TASKS = 'tasks',
+	SMART_OBJECTS = 'smart_objects',
+}
+
+export enum EOAuthPermissionAction {
+	CREATE = 'create',
+	VIEW = 'view',
+	EDIT = 'edit',
+	DELETE = 'delete',
+}
+
 // A permission group for the FE granular selector.
 export interface IOAuthPermissionGroup {
 	key: string; // area.entity, e.g. 'crm.leads'
 	title: string;
 	entity: string; // area.entity
-	section: string; // 'crm' | 'tasks' | 'smart_objects'
-	actions: string[]; // ['create','view','edit','delete']
+	section: EOAuthPermissionSection;
+	actions: EOAuthPermissionAction[];
 	permissionKeys: {
 		create: string;
 		view: string;

--- a/src/services/OAuthClientsService/dto/create-oauth-client.dto.ts
+++ b/src/services/OAuthClientsService/dto/create-oauth-client.dto.ts
@@ -1,0 +1,4 @@
+export interface IOAuthClientRequest {
+	name: string;
+	permissions: string[];
+}

--- a/src/services/OAuthClientsService/index.ts
+++ b/src/services/OAuthClientsService/index.ts
@@ -1,7 +1,7 @@
 import { injectable } from 'tsyringe';
 
 import { HttpClient } from '../../core/HttpClient';
-import { IApiEnvelope, IOAuthClientsPaginator, IOAuthClientWithSecret, IOAuthPermissionGroup } from '../../models/oauthClients';
+import { IApiEnvelope, IOAuthClient, IOAuthClientsPaginator, IOAuthClientWithSecret, IOAuthPermissionGroup } from '../../models/oauthClients';
 import { IOAuthClientRequest } from './dto/create-oauth-client.dto';
 
 /**
@@ -26,6 +26,14 @@ export class OAuthClientsService {
 	 */
 	createOAuthClient(body: IOAuthClientRequest) {
 		return this.httpClient.client.post<IApiEnvelope<IOAuthClientWithSecret>>(this.namespace, body);
+	}
+
+	/**
+	 * Update an OAuth client (name and/or permissions) by id (client_id).
+	 * The secret is never returned on update.
+	 */
+	updateOAuthClient(id: string, body: Partial<IOAuthClientRequest>) {
+		return this.httpClient.client.patch<IApiEnvelope<IOAuthClient>>(`${this.namespace}/:id`, body, { urlParams: { id } });
 	}
 
 	/**

--- a/src/services/OAuthClientsService/index.ts
+++ b/src/services/OAuthClientsService/index.ts
@@ -1,0 +1,44 @@
+import { injectable } from 'tsyringe';
+
+import { HttpClient } from '../../core/HttpClient';
+import { IApiEnvelope, IOAuthClientsPaginator, IOAuthClientWithSecret, IOAuthPermissionGroup } from '../../models/oauthClients';
+import { IOAuthClientRequest } from './dto/create-oauth-client.dto';
+
+/**
+ * OAuth clients service (External connectors).
+ */
+@injectable()
+export class OAuthClientsService {
+	private namespace = '/company/v1/oauth_clients';
+
+	constructor(private httpClient: HttpClient) {}
+
+	/**
+	 * Get the workspace's OAuth clients.
+	 */
+	getOAuthClients() {
+		return this.httpClient.client.get<IApiEnvelope<IOAuthClientsPaginator>>(this.namespace);
+	}
+
+	/**
+	 * Create an OAuth client. Returns the client including the one-time secret.
+	 * @param body name + selected permission keys (area.entity.action)
+	 */
+	createOAuthClient(body: IOAuthClientRequest) {
+		return this.httpClient.client.post<IApiEnvelope<IOAuthClientWithSecret>>(this.namespace, body);
+	}
+
+	/**
+	 * Delete an OAuth client by id (client_id).
+	 */
+	deleteOAuthClient(id: string) {
+		return this.httpClient.client.delete<{ status: boolean; message: string }>(`${this.namespace}/:id`, { urlParams: { id } });
+	}
+
+	/**
+	 * Get the available permissions catalog for the client scope selector.
+	 */
+	getAvailablePermissions() {
+		return this.httpClient.client.get<IApiEnvelope<IOAuthPermissionGroup[]>>(`${this.namespace}/available_permissions`);
+	}
+}

--- a/src/services/OAuthClientsService/index.ts
+++ b/src/services/OAuthClientsService/index.ts
@@ -16,8 +16,8 @@ export class OAuthClientsService {
 	/**
 	 * Get the workspace's OAuth clients.
 	 */
-	getOAuthClients() {
-		return this.httpClient.client.get<IApiEnvelope<IOAuthClientsPaginator>>(this.namespace);
+	getOAuthClients(page?: number, list?: number) {
+		return this.httpClient.client.get<IApiEnvelope<IOAuthClientsPaginator>>(this.namespace, { params: { page, list } });
 	}
 
 	/**


### PR DESCRIPTION
## What

Add an `OAuthClientsService` for the profile-frontend **External connectors** tab. Wraps users-backend `company/v1/oauth_clients` (list / create / delete + `available_permissions`), mirroring `WebhooksService`.

> Part of a multi-repo OAuth-clients feature: auth-service (client API + token permission scoping) → users-backend (`company/v1/oauth_clients` proxy) → this SDK → uspacy-store slice → profile-frontend tab.

## Changes

- **`services/OAuthClientsService`**: `getOAuthClients`, `createOAuthClient`, `deleteOAuthClient`, `getAvailablePermissions` (+ `dto/create-oauth-client.dto.ts`).
- **`models/oauthClients.ts`** (camelCase, matching the users-backend camelCased responses):
  - `IOAuthClient`, `IOAuthClientWithSecret` (create returns the one-time `secret`), `IOAuthPermissionGroup`.
  - `IOAuthClientsPaginator` (the flat Laravel paginator) + `IApiEnvelope<T>` (the `{ status, data }` response envelope).
- Service generics typed as `IApiEnvelope<...>`, so consumers unwrap `response.data.data` (and `response.data.data.data` for the list paginator) in a type-guided way.
- Registered in the `Uspacy` container (`src/index.ts`).

## Notes

- The plaintext `client_secret` is only present on the create response (`IOAuthClientWithSecret`); consumers must show it once and never persist it.
- `tsc --noEmit` + eslint clean.

## Follow-up

profile-frontend pins a published `@uspacy/sdk`; after this merges and is **published**, bump the version there to consume `oauthClientsService` (the store slice + FE tab are ready and guard on its presence until then).
