### PR TITLE
feat(messenger): external chats cursor pagination (getExternalChatsPage)

### DIFF
--- a/src/models/messenger.ts
+++ b/src/models/messenger.ts
@@ -180,12 +180,30 @@ export interface IFetchChatsParams {
 	page?: number;
 	list?: number;
 	withoutAnswers?: boolean;
-	// Filter by external statuses (comma-separated active,inactive,undistributed)
+	// Filter by external statuses (comma-separated active,inactive,undistributed).
+	// In cursor mode this must be a single status: 'active' | 'undistributed' | 'inactive'.
 	externalStatuses?: string;
 	// Filter by member ids (comma-separated)
 	members?: string;
 	// Filter by responder ids (comma-separated)
 	responder?: string;
+	// Cursor pagination (external chats). When `cursor` or `limit` is set, the endpoint
+	// returns ICursorPaginatedChats instead of a bare IChat[] — use getExternalChatsPage.
+	cursor?: string;
+	limit?: number;
+}
+
+export type IExternalChatStatus = 'active' | 'undistributed' | 'inactive';
+
+/**
+ * Cursor (keyset) paginated external chats response.
+ * `pinned` is present only on the first page (no `cursor`).
+ */
+export interface ICursorPaginatedChats {
+	pinned?: IChat[];
+	data: IChat[];
+	nextCursor: string | null;
+	hasNext: boolean;
 }
 
 export interface IMessagesGroup {

--- a/src/services/MessengerService/index.ts
+++ b/src/services/MessengerService/index.ts
@@ -7,6 +7,7 @@ import {
 	IChat,
 	ICreateQuickAnswerDTO,
 	ICreateWidgetData,
+	ICursorPaginatedChats,
 	IFetchChatsParams,
 	IGetQuickAnswerParams,
 	IQuickAnswer,
@@ -30,6 +31,19 @@ export class MessengerService {
 	async getChats(props: IFetchChatsParams) {
 		return this.httpClient.client.get<IChat[]>(`${this.namespace}/chats`, {
 			params: { ...props },
+		});
+	}
+
+	/**
+	 * Get a cursor (keyset) paginated page of external chats for one status bucket.
+	 * Hits the same `/chats` endpoint but engages cursor mode (`cursor`/`limit` present)
+	 * and returns ICursorPaginatedChats: `{ pinned?, data, nextCursor, hasNext }`.
+	 * Pass `externalStatuses` as a single status ('active' | 'undistributed' | 'inactive').
+	 * Omit `cursor` for the first page (which also returns the `pinned` block).
+	 */
+	async getExternalChatsPage(props: IFetchChatsParams) {
+		return this.httpClient.client.get<ICursorPaginatedChats>(`${this.namespace}/chats`, {
+			params: { type: 'EXTERNAL', ...props },
 		});
 	}
 


### PR DESCRIPTION
## What & why

Adds the SDK surface for **external-chats cursor (keyset) pagination**, consumed by `@uspacy/store` and `chat-frontend`. Backend: messenger-backend #330.

## Changes (backward compatible)

- `IFetchChatsParams`: add `cursor?: string` and `limit?: number` (`externalStatuses`/`members`/`responder` already existed). In cursor mode `externalStatuses` is a **single** status.
- New types: `ICursorPaginatedChats { pinned?, data, nextCursor, hasNext }`, `IExternalChatStatus = 'active' | 'undistributed' | 'inactive'`.
- New method `MessengerService.getExternalChatsPage(props)` → typed `AxiosResponse<ICursorPaginatedChats>`, hits the same `/messenger/v1/chats` endpoint in cursor mode. `getChats` is **unchanged** (still `IChat[]`).

## Verify

- `yarn eslint` on changed files: clean.
- `yarn emitDeclarations` (tsc project typecheck): passes.
- No tests in this repo (typed HTTP-client wrapper).

## Chain

`@uspacy/sdk` (this) → `@uspacy/store` → `chat-frontend`. Publish this, bump in store, then chat-frontend.