### PR TITLE
feat(messenger): external chats cursor pagination (getExternalChatsPage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uspacy/sdk",
-  "version": "0.0.241",
+  "version": "0.0.243",
   "repository": "git@github.com:Uspacy/uspacy-js-sdk.git",
   "homepage": "https://uspacy.github.io/uspacy-js-sdk",
   "keywords": [],

--- a/src/models/messenger.ts
+++ b/src/models/messenger.ts
@@ -179,12 +179,30 @@ export interface IFetchChatsParams {
 	page?: number;
 	list?: number;
 	withoutAnswers?: boolean;
-	// Filter by external statuses (comma-separated active,inactive,undistributed)
+	// Filter by external statuses (comma-separated active,inactive,undistributed).
+	// In cursor mode this must be a single status: 'active' | 'undistributed' | 'inactive'.
 	externalStatuses?: string;
 	// Filter by member ids (comma-separated)
 	members?: string;
 	// Filter by responder ids (comma-separated)
 	responder?: string;
+	// Cursor pagination (external chats). When `cursor` or `limit` is set, the endpoint
+	// returns ICursorPaginatedChats instead of a bare IChat[] — use getExternalChatsPage.
+	cursor?: string;
+	limit?: number;
+}
+
+export type IExternalChatStatus = 'active' | 'undistributed' | 'inactive';
+
+/**
+ * Cursor (keyset) paginated external chats response.
+ * `pinned` is present only on the first page (no `cursor`).
+ */
+export interface ICursorPaginatedChats {
+	pinned?: IChat[];
+	data: IChat[];
+	nextCursor: string | null;
+	hasNext: boolean;
 }
 
 export interface IMessagesGroup {

--- a/src/models/messenger.ts
+++ b/src/models/messenger.ts
@@ -181,7 +181,7 @@ export interface IFetchChatsParams {
 	withoutAnswers?: boolean;
 	// Filter by external statuses (comma-separated active,inactive,undistributed).
 	// In cursor mode this must be a single status: 'active' | 'undistributed' | 'inactive'.
-	externalStatuses?: string;
+	externalStatuses?: IExternalChatStatus | string;
 	// Filter by member ids (comma-separated)
 	members?: string;
 	// Filter by responder ids (comma-separated)

--- a/src/services/MessengerService/index.ts
+++ b/src/services/MessengerService/index.ts
@@ -7,6 +7,7 @@ import {
 	IChat,
 	ICreateQuickAnswerDTO,
 	ICreateWidgetData,
+	ICursorPaginatedChats,
 	IFetchChatsParams,
 	IGetQuickAnswerParams,
 	IQuickAnswer,
@@ -30,6 +31,19 @@ export class MessengerService {
 	async getChats(props: IFetchChatsParams) {
 		return this.httpClient.client.get<IChat[]>(`${this.namespace}/chats`, {
 			params: { ...props },
+		});
+	}
+
+	/**
+	 * Get a cursor (keyset) paginated page of external chats for one status bucket.
+	 * Hits the same `/chats` endpoint but engages cursor mode (`cursor`/`limit` present)
+	 * and returns ICursorPaginatedChats: `{ pinned?, data, nextCursor, hasNext }`.
+	 * Pass `externalStatuses` as a single status ('active' | 'undistributed' | 'inactive').
+	 * Omit `cursor` for the first page (which also returns the `pinned` block).
+	 */
+	async getExternalChatsPage(props: IFetchChatsParams) {
+		return this.httpClient.client.get<ICursorPaginatedChats>(`${this.namespace}/chats`, {
+			params: { type: 'EXTERNAL', ...props },
 		});
 	}
 

--- a/src/services/MessengerService/index.ts
+++ b/src/services/MessengerService/index.ts
@@ -43,7 +43,8 @@ export class MessengerService {
 	 */
 	async getExternalChatsPage(props: IFetchChatsParams) {
 		return this.httpClient.client.get<ICursorPaginatedChats>(`${this.namespace}/chats`, {
-			params: { type: 'EXTERNAL', ...props },
+			// `type` set last so a caller-supplied `type` (incl. explicit undefined) can't override it.
+			params: { ...props, type: 'EXTERNAL' },
 		});
 	}
 


### PR DESCRIPTION
## What & why

Brings the external-chats **cursor (keyset) pagination** SDK surface into `main` (it currently lives only on `stage`; the earlier PR #255 was merged into stage). Consumed by `@uspacy/store` and `chat-frontend`; backend: messenger-backend #330.

## Changes (backward compatible)

- `IFetchChatsParams`: add `cursor?: string` and `limit?: number` (`externalStatuses`/`members`/`responder` already existed). In cursor mode `externalStatuses` is a **single** status.
- New types: `ICursorPaginatedChats { pinned?, data, nextCursor, hasNext }`, `IExternalChatStatus = 'active' | 'undistributed' | 'inactive'`.
- New method `MessengerService.getExternalChatsPage(props)` → typed `AxiosResponse<ICursorPaginatedChats>`, hits the same `/messenger/v1/chats` endpoint in cursor mode. `getChats` is **unchanged** (still `IChat[]`).

## Verify

- `yarn eslint` on changed files: clean.
- `yarn emitDeclarations` (tsc project typecheck): passes.
- No test suite in this repo (typed HTTP-client wrapper).

## Note

Same change already merged to `stage` (PR #255). This PR promotes it to `main`.