### PR TITLE
[8894] feat(profile): custom user status methods (get/set/clear)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uspacy/sdk",
-  "version": "0.0.244",
+  "version": "0.0.247",
   "repository": "git@github.com:Uspacy/uspacy-js-sdk.git",
   "homepage": "https://uspacy.github.io/uspacy-js-sdk",
   "keywords": [],

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -53,6 +53,7 @@ export interface IUser {
 	external_user: boolean;
 	isOnline: boolean;
 	lastSeenAt: number;
+	status: IUserStatus | null;
 	[key: string]: any;
 }
 
@@ -74,6 +75,19 @@ export interface IUserFilter {
 export interface IOnlineStatus {
 	isOnline: boolean;
 	lastSeenAt: number;
+}
+
+/**
+ * Slack-like custom user status (emoji + title + description + optional expiry).
+ * Separate from presence (isOnline / lastSeenAt). `removeStatusAfter` is a unix
+ * timestamp in seconds; `null` means the status never expires.
+ */
+export interface IUserStatus {
+	emoji: string;
+	title: string | null;
+	description: string | null;
+	removeStatusAfter: number | null;
+	setAt: number | null;
 }
 
 export interface IUserOnlineStatuses {

--- a/src/services/ProfileService/dto/set-status.dto.ts
+++ b/src/services/ProfileService/dto/set-status.dto.ts
@@ -1,0 +1,11 @@
+/**
+ * Payload for setting the current user's Slack-like custom status.
+ * `emoji` is required; `removeStatusAfter` is a future unix timestamp in seconds
+ * (or null / omitted for a status that never expires).
+ */
+export interface ISetUserStatusDto {
+	emoji: string;
+	title?: string | null;
+	description?: string | null;
+	removeStatusAfter?: number | null;
+}

--- a/src/services/ProfileService/index.ts
+++ b/src/services/ProfileService/index.ts
@@ -6,7 +6,8 @@ import { IField } from '../../models/field';
 import { IRequisite, IRequisitesResponse, IRequisiteUpdate, ITemplate, ITemplateResponse, ITemplateUpdate } from '../../models/requisites';
 import { IResponseWithMessage } from '../../models/response';
 import { IPortalSettings } from '../../models/settings';
-import { IOnlineStatus, IUser } from '../../models/user';
+import { IOnlineStatus, IUser, IUserStatus } from '../../models/user';
+import { ISetUserStatusDto } from './dto/set-status.dto';
 
 /**
  * Users service
@@ -239,5 +240,29 @@ export class ProfileService {
 
 	getProfileOnlineStatus() {
 		return this.httpClient.client.get<IOnlineStatus>(`${this.namespace}/online`);
+	}
+
+	/**
+	 * Get the current user's Slack-like custom status
+	 * @returns the active status, or null when there is none
+	 */
+	getStatus() {
+		return this.httpClient.client.get<{ status: IUserStatus | null }>(`${this.namespace}/status`);
+	}
+
+	/**
+	 * Set (create or overwrite) the current user's custom status
+	 * @param body emoji (required) + optional title, description and removeStatusAfter
+	 * @returns the saved status
+	 */
+	setStatus(body: ISetUserStatusDto) {
+		return this.httpClient.client.post<{ status: IUserStatus | null }>(`${this.namespace}/status`, body);
+	}
+
+	/**
+	 * Clear (delete) the current user's custom status
+	 */
+	clearStatus() {
+		return this.httpClient.client.delete<{ status: null }>(`${this.namespace}/status`);
 	}
 }


### PR DESCRIPTION
## What

Expose the Slack-like custom user status endpoints on `ProfileService`, so frontends set/clear a user's own status through the SDK (no direct httpClient calls).

- `getStatus()`   → `GET /company/v1/users/me/status`
- `setStatus(dto)` → `POST /company/v1/users/me/status`
- `clearStatus()` → `DELETE /company/v1/users/me/status`

## Changes

- `IUserStatus` model (emoji, title, description, removeStatusAfter, setAt) + `status` field on `IUser`.
- `ISetUserStatusDto` payload (emoji required; title/description/removeStatusAfter optional).
- Three `ProfileService` methods above.

Backend: Uspacy/users-backend#428.

## Verify

- `eslint` — clean
- `tsc --noEmit` — no errors